### PR TITLE
Add documentation about configuring local certificates in MacOS.

### DIFF
--- a/docs/configure-https.md
+++ b/docs/configure-https.md
@@ -6,7 +6,7 @@ When developing applications that require HTTPS, one effective method is to use 
 > [!CAUTION]
 > **Important Note**: This process is intended for development purposes only. Using self-signed certificates in a production environment is not recommended as it can expose your application to security vulnerabilities.
 
-## Generating the Certificate
+## Generating the Certificate using OpenSSL
 
 ### Bash
 ```bash
@@ -32,6 +32,10 @@ $ReqConf | Out-File -FilePath .\openssl.cnf -Encoding ascii
 openssl req -x509 -out localhost.crt -keyout localhost.key -newkey rsa:2048 -nodes -sha256 -subj '/CN=localhost' -days 365 -extensions EXT -config .\openssl.cnf
 ```
 
+## Generating the Certificate using Powershell
+
+TODO
+
 ## Trusting the Certificate
 
 Since the certificate you just generated is not signed by a trusted certificate authority, browsers will complain about the connection being unsafe. To resolve this we can either configure our browsers or our system to trust the certificate.
@@ -50,7 +54,14 @@ certutil -addStore "root" <path-to-crt-file>
 
 #### MacOS
 
-TODO
+To configure system level trust for your certificate you need to import it into your keychain:
+
+1. Open the `Keychain Access` app.
+1. Open your `login` keychain.
+1. Import the certificate by going to `File->Import Items` and finding the `crt` file you created.
+1. Once imported, double click it; expand the `Trust` section and set the `Secure Socket Layer (SSL)` option to `Always Trust`.
+1. Once that is done, close the certificate config window and you will be asked to confirm by authenticating. Done that your certificate is trusted.
+
 
 #### Linux
 


### PR DESCRIPTION
This pull request to `docs/configure-https.md` includes changes to improve the documentation for generating and trusting HTTPS certificates. The most important changes include specifying that OpenSSL is used to generate the certificate, adding a placeholder for a new section on generating the certificate using Powershell, and providing instructions for trusting the certificate on MacOS.

Changes to certificate generation:

* [`docs/configure-https.md`](diffhunk://#diff-be95a41a9019455cb298fbcc457be71e53b7ffe7e590cd7b9cbc532d4083fa76L9-R9): Renamed the section "Generating the Certificate" to "Generating the Certificate using OpenSSL" to specify the method used.
* [`docs/configure-https.md`](diffhunk://#diff-be95a41a9019455cb298fbcc457be71e53b7ffe7e590cd7b9cbc532d4083fa76R35-R38): Added a new section "Generating the Certificate using Powershell" with a placeholder for future content.

Changes to certificate trusting:

* [`docs/configure-https.md`](diffhunk://#diff-be95a41a9019455cb298fbcc457be71e53b7ffe7e590cd7b9cbc532d4083fa76L53-R64): Added instructions to the MacOS subsection under "Trusting the Certificate" for importing the certificate into the keychain and setting it to "Always Trust".